### PR TITLE
feat: ajouter la gestion de la langue dans les fichiers Markdown

### DIFF
--- a/docs/FORMAT_MARKDOWN.md
+++ b/docs/FORMAT_MARKDOWN.md
@@ -1,159 +1,229 @@
-# Guide de migration - De l'ancienne dictée au format Markdown
+# Format Markdown pour les dictées
 
-Ce document explique comment migrer des dictées depuis l'ancienne version de l'application (basée sur les paramètres URL) vers le nouveau format Markdown.
+Ce document spécifie le format Markdown utilisé pour stocker et partager les dictées dans l'application.
 
-## Comprendre l'ancien format
+## Format de base
 
-Dans l'ancienne version de l'application, les dictées étaient stockées dans l'URL sous forme de paramètres :
+Une dictée au format Markdown suit cette structure :
 
-```
-https://micetf.fr/dictee/?tl=fr&titre=Les+mois+de+l%27ann%C3%A9e&d[1]=106|97|110|118|105|101|114|&d[2]=102|233|118|114|105|101|114|&d[3]=109|97|114|115|
-```
+```markdown
+# Titre de la dictée
 
-Où :
+<!-- lang:fr -->
 
--   `tl` est le code de langue (fr, en, es, de, it)
--   `titre` est le titre de la dictée (encodé en URL)
--   `d[1]`, `d[2]`, etc. sont les phrases encodées en valeurs ASCII séparées par des barres verticales
-
-## Méthodes de migration
-
-### 1. Migration automatique via l'outil intégré
-
-L'application Dictée Markdown intègre un outil de migration automatique :
-
-1. Dans l'application, cliquez sur "Migrer une ancienne dictée"
-2. Collez l'URL complète de l'ancienne dictée
-3. Cliquez sur "Convertir"
-4. L'application analysera l'URL, décodera les phrases et générera la version Markdown
-5. Vérifiez le résultat et cliquez sur "Enregistrer" pour sauvegarder la dictée
-
-### 2. Migration manuelle
-
-Si vous préférez migrer manuellement :
-
-1. Ouvrez l'ancienne dictée dans votre navigateur
-2. Notez le titre
-3. Listez toutes les phrases en utilisant le bouton "Écouter" pour chacune
-4. Créez un nouveau fichier Markdown avec la structure correcte :
-
-    ```markdown
-    # Titre de la dictée
-
-    1. Première phrase
-    2. Deuxième phrase
-       ...
-    ```
-
-5. Importez ce fichier dans la nouvelle application
-
-## Décodage de l'ancien format
-
-Pour les utilisateurs techniques qui souhaitent comprendre ou implémenter leur propre décodeur :
-
-### Processus de décodage
-
-```javascript
-// Décode une phrase depuis l'ancien format
-function decodeOldPhrase(encodedPhrase) {
-    // Divise la chaîne en codes ASCII séparés par |
-    const codes = encodedPhrase.split("|");
-
-    // Convertit chaque code en caractère et les joint
-    return codes
-        .filter((code) => code !== "")
-        .map((code) => String.fromCharCode(parseInt(code, 10)))
-        .join("");
-}
-
-// Exemple d'utilisation
-const oldEncodedPhrase = "106|97|110|118|105|101|114|";
-const decodedPhrase = decodeOldPhrase(oldEncodedPhrase);
-console.log(decodedPhrase); // "janvier"
+1. Première phrase de la dictée.
+2. Deuxième phrase de la dictée.
+3. Troisième phrase de la dictée.
 ```
 
-### Exemple de conversion complète
+## Spécifications détaillées
 
-```javascript
-// Convertit une URL complète en objet dictée
-function convertOldUrlToDictee(url) {
-    // Extrait les paramètres de l'URL
-    const params = new URLSearchParams(url.split("?")[1]);
+### Titre
 
-    // Récupère le titre (décode l'URL encoding)
-    const title = decodeURIComponent(params.get("titre") || "Sans titre");
+-   Le titre doit être précédé d'un `#` et un espace
+-   Il doit apparaître sur la première ligne non vide du document
+-   Un seul titre par document est autorisé
+-   Exemple : `# Les mois de l'année`
 
-    // Récupère la langue
-    const language = params.get("tl") || "fr";
+### Métadonnées
 
-    // Tableau pour stocker les phrases décodées
-    const sentences = [];
+Les métadonnées peuvent être ajoutées de deux façons :
 
-    // Parcourt les paramètres d[1] à d[20]
-    for (let i = 1; i <= 20; i++) {
-        const encodedPhrase = params.get(`d[${i}]`);
-        if (encodedPhrase) {
-            const decodedPhrase = decodeOldPhrase(encodedPhrase);
-            if (decodedPhrase) {
-                sentences.push(decodedPhrase);
-            }
-        }
-    }
+#### 1. Commentaires HTML (Recommandé)
 
-    // Conversion au format Markdown
-    let markdown = `# ${title}\n\n`;
-    sentences.forEach((sentence, index) => {
-        markdown += `${index + 1}. ${sentence}\n`;
-    });
+Pour une meilleure compatibilité avec tous les éditeurs Markdown, utilisez des commentaires HTML pour les métadonnées essentielles :
 
-    return markdown;
-}
+```markdown
+# Titre de la dictée
+
+<!-- lang:fr-FR -->
+
+1. Première phrase.
 ```
 
-## Mapping des codes de langue
+#### 2. YAML Frontmatter (Avancé)
 
-Le tableau suivant montre la correspondance entre les anciens codes de langue et les nouveaux :
+Pour des métadonnées plus complètes, vous pouvez utiliser le format YAML frontmatter :
 
-| Ancien code | Nouveau code |
-| ----------- | ------------ |
-| fr          | fr-FR        |
-| en          | en-US        |
-| es          | es-ES        |
-| de          | de-DE        |
-| it          | it-IT        |
+```markdown
+---
+language: fr-FR
+random: true
+author: Prénom Nom
+created: 2023-04-15
+---
 
-## Limites et considérations
+# Titre de la dictée
 
-### Limites de la migration automatique
+1. Première phrase.
+```
 
--   Les formatages spéciaux (gras, italique) ne sont pas présents dans l'ancien format et ne seront donc pas récupérés
--   Les métadonnées avancées (auteur, niveau, etc.) devront être ajoutées manuellement
--   Le paramètre d'ordre aléatoire (`a=1`) est converti, mais d'autres paramètres peuvent être perdus
+**Note importante** : L'application privilégie les métadonnées au format commentaire HTML pour la langue. Si les deux formats sont présents, le commentaire HTML sera prioritaire.
 
-### Avantages du nouveau format
+#### Métadonnées supportées
 
--   Meilleure lisibilité
--   URLs plus courtes
--   Possibilité d'ajouter des métadonnées et du formatage
--   Compatibilité avec des éditeurs Markdown externes
--   Stockage local ou cloud du fichier .md
+| Clé      | Description          | Valeurs possibles              | Par défaut    |
+| -------- | -------------------- | ------------------------------ | ------------- |
+| language | Code de langue       | Codes ISO (ex: fr-FR, en-US)   | fr            |
+| random   | Ordre aléatoire      | true/false                     | false         |
+| author   | Auteur de la dictée  | Texte                          | Non défini    |
+| created  | Date de création     | YYYY-MM-DD                     | Date actuelle |
+| tags     | Mots-clés associés   | Liste séparée par des virgules | Non défini    |
+| level    | Niveau de difficulté | easy, medium, hard             | medium        |
+| category | Catégorie thématique | Texte                          | Non défini    |
 
-## FAQ sur la migration
+### Langue de la dictée
 
-**Q : Puis-je migrer plusieurs dictées à la fois ?**  
-R : Non, l'outil de migration traite une dictée à la fois. Pour les utilisateurs avec de nombreuses dictées, contactez-nous pour une solution personnalisée.
+La langue est indiquée juste après le titre, avant les phrases :
 
-**Q : Les anciennes URLs continueront-elles à fonctionner ?**  
-R : Oui, pour assurer la compatibilité, les anciennes URLs resteront fonctionnelles, mais un message vous invitera à migrer vers le nouveau format.
+```markdown
+# Titre de la dictée
 
-**Q : Que se passe-t-il si la conversion échoue ?**  
-R : L'application affichera un message d'erreur précis. Vous pourrez alors essayer la méthode de migration manuelle ou nous contacter pour obtenir de l'aide.
+<!-- lang:fr -->
 
-**Q : Comment partager mes dictées migrées ?**  
-R : Après la migration, vous pouvez télécharger le fichier Markdown et le partager par e-mail, services cloud ou via l'URL directe générée par l'application.
+1. Première phrase de la dictée.
+2. Deuxième phrase de la dictée.
+```
 
-## Ressources supplémentaires
+Les codes de langue valides incluent :
 
--   [Guide d'utilisation](GUIDE_UTILISATION.md) - Pour en savoir plus sur l'utilisation de la nouvelle application
--   [Format Markdown](FORMAT_MARKDOWN.md) - Documentation détaillée du format Markdown utilisé
--   [Exemples de dictées](https://github.com/micetf/dictee-markdown/tree/main/examples) - Collection d'exemples au format Markdown
+-   Codes courts : `fr`, `en`, `es`, `de`, `it`
+-   Codes régionaux : `fr-FR`, `fr-CA`, `en-US`, `en-GB`, `es-ES`, etc.
+
+La langue spécifiée sera utilisée pour configurer la synthèse vocale lors de la lecture de la dictée.
+
+### Phrases
+
+-   Chaque phrase doit commencer par un numéro suivi d'un point et d'un espace (`1. `)
+-   Les phrases sont numérotées séquentiellement à partir de 1
+-   Chaque phrase doit apparaître sur une ligne distincte
+-   Une phrase peut contenir des formatages Markdown (gras, italique, etc.)
+-   Exemple : `1. Voici **une** phrase avec du *formatage*. `
+
+## Extensions et formatages
+
+### Formatage du texte
+
+Les dictées peuvent utiliser les éléments de formatage Markdown suivants :
+
+-   **Gras** : `**texte en gras**` ou `__texte en gras__`
+-   _Italique_ : `*texte en italique*` ou `_texte en italique_`
+-   **_Gras et italique_** : `**_texte en gras et italique_**`
+-   ~~Barré~~ : `~~texte barré~~`
+-   `Code` : `` `code` ``
+
+Ces formatages peuvent être utiles pour mettre en évidence certains éléments grammaticaux ou orthographiques.
+
+### Annotations pédagogiques
+
+Des annotations pédagogiques peuvent être ajoutées entre crochets après une phrase :
+
+```markdown
+1. Cette phrase contient un participe passé. [Attention à l'accord]
+2. Voici une phrase avec des homophones. [Distinguer "est" et "et"]
+```
+
+### Groupes de mots
+
+Pour les dictées de mots (par opposition aux phrases complètes), utilisez cette syntaxe :
+
+```markdown
+# Dictée de mots - Homophones
+
+<!-- lang:fr -->
+
+1. ver, verre, vers, vert
+2. mer, mère, maire
+3. pain, pin, peint
+```
+
+## Exemples complets
+
+### Exemple 1 : Dictée simple
+
+```markdown
+# Les saisons
+
+<!-- lang:fr -->
+
+1. L'hiver est la saison la plus froide de l'année.
+2. Au printemps, les fleurs commencent à éclore.
+3. L'été est caractérisé par des journées chaudes et ensoleillées.
+4. En automne, les feuilles des arbres changent de couleur et tombent.
+```
+
+### Exemple 2 : Dictée avec métadonnées et formatage
+
+```markdown
+---
+random: false
+author: Jean Dupont
+created: 2023-05-12
+tags: grammaire, accord, participe passé
+level: medium
+category: Règles grammaticales
+---
+
+# Les participes passés
+
+<!-- lang:fr-FR -->
+
+1. Les fleurs que j'ai **cueillies** sont magnifiques.
+2. Ma sœur est **partie** en voyage hier soir.
+3. Les efforts qu'ils ont **fournis** ont été récompensés.
+4. Elles se sont **regardées** en souriant.
+```
+
+### Exemple 3 : Dictée de mots en anglais
+
+```markdown
+# Days of the week
+
+<!-- lang:en-US -->
+
+1. Monday
+2. Tuesday
+3. Wednesday
+4. Thursday
+5. Friday
+6. Saturday
+7. Sunday
+```
+
+## Validation et compatibilité
+
+### Validation
+
+Un document de dictée est considéré valide s'il contient au minimum :
+
+-   Un titre précédé de `#`
+-   Au moins une phrase numérotée
+
+### Compatibilité
+
+Les fichiers Markdown sans métadonnées de langue seront toujours reconnus, et la langue sera définie par défaut à "fr" (français).
+
+### Compatibilité avec d'autres applications
+
+Le format choisi est compatible avec la plupart des éditeurs et visualiseurs Markdown :
+
+-   Visual Studio Code
+-   Typora
+-   Obsidian
+-   GitLab/GitHub Markdown
+-   Notion (avec quelques limitations pour les métadonnées)
+
+La métadonnée de langue au format commentaire HTML est invisible dans la plupart des prévisualisations Markdown, ce qui préserve la lisibilité du document.
+
+## Migration depuis l'ancien format
+
+Pour convertir une dictée depuis l'ancien format URL, utilisez la fonction de migration de l'application. Les étapes sont détaillées dans le [guide de migration](MIGRATION.md).
+
+## Bonnes pratiques
+
+-   Limitez les dictées à 20 phrases maximum pour une expérience utilisateur optimale
+-   Utilisez un titre concis et descriptif
+-   Spécifiez toujours la langue pour une meilleure expérience avec la synthèse vocale
+-   Pour les dictées pédagogiques, incluez le niveau scolaire dans les métadonnées
+-   Évitez d'utiliser des caractères spéciaux qui pourraient causer des problèmes d'encodage
+-   Vérifiez toujours la dictée avec la fonction de prévisualisation avant de la partager

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,159 @@
+# Guide de migration - De l'ancienne dictée au format Markdown
+
+Ce document explique comment migrer des dictées depuis l'ancienne version de l'application (basée sur les paramètres URL) vers le nouveau format Markdown.
+
+## Comprendre l'ancien format
+
+Dans l'ancienne version de l'application, les dictées étaient stockées dans l'URL sous forme de paramètres :
+
+```
+https://micetf.fr/dictee/?tl=fr&titre=Les+mois+de+l%27ann%C3%A9e&d[1]=106|97|110|118|105|101|114|&d[2]=102|233|118|114|105|101|114|&d[3]=109|97|114|115|
+```
+
+Où :
+
+-   `tl` est le code de langue (fr, en, es, de, it)
+-   `titre` est le titre de la dictée (encodé en URL)
+-   `d[1]`, `d[2]`, etc. sont les phrases encodées en valeurs ASCII séparées par des barres verticales
+
+## Méthodes de migration
+
+### 1. Migration automatique via l'outil intégré
+
+L'application Dictée Markdown intègre un outil de migration automatique :
+
+1. Dans l'application, cliquez sur "Migrer une ancienne dictée"
+2. Collez l'URL complète de l'ancienne dictée
+3. Cliquez sur "Convertir"
+4. L'application analysera l'URL, décodera les phrases et générera la version Markdown
+5. Vérifiez le résultat et cliquez sur "Enregistrer" pour sauvegarder la dictée
+
+### 2. Migration manuelle
+
+Si vous préférez migrer manuellement :
+
+1. Ouvrez l'ancienne dictée dans votre navigateur
+2. Notez le titre
+3. Listez toutes les phrases en utilisant le bouton "Écouter" pour chacune
+4. Créez un nouveau fichier Markdown avec la structure correcte :
+
+    ```markdown
+    # Titre de la dictée
+
+    1. Première phrase
+    2. Deuxième phrase
+       ...
+    ```
+
+5. Importez ce fichier dans la nouvelle application
+
+## Décodage de l'ancien format
+
+Pour les utilisateurs techniques qui souhaitent comprendre ou implémenter leur propre décodeur :
+
+### Processus de décodage
+
+```javascript
+// Décode une phrase depuis l'ancien format
+function decodeOldPhrase(encodedPhrase) {
+    // Divise la chaîne en codes ASCII séparés par |
+    const codes = encodedPhrase.split("|");
+
+    // Convertit chaque code en caractère et les joint
+    return codes
+        .filter((code) => code !== "")
+        .map((code) => String.fromCharCode(parseInt(code, 10)))
+        .join("");
+}
+
+// Exemple d'utilisation
+const oldEncodedPhrase = "106|97|110|118|105|101|114|";
+const decodedPhrase = decodeOldPhrase(oldEncodedPhrase);
+console.log(decodedPhrase); // "janvier"
+```
+
+### Exemple de conversion complète
+
+```javascript
+// Convertit une URL complète en objet dictée
+function convertOldUrlToDictee(url) {
+    // Extrait les paramètres de l'URL
+    const params = new URLSearchParams(url.split("?")[1]);
+
+    // Récupère le titre (décode l'URL encoding)
+    const title = decodeURIComponent(params.get("titre") || "Sans titre");
+
+    // Récupère la langue
+    const language = params.get("tl") || "fr";
+
+    // Tableau pour stocker les phrases décodées
+    const sentences = [];
+
+    // Parcourt les paramètres d[1] à d[20]
+    for (let i = 1; i <= 20; i++) {
+        const encodedPhrase = params.get(`d[${i}]`);
+        if (encodedPhrase) {
+            const decodedPhrase = decodeOldPhrase(encodedPhrase);
+            if (decodedPhrase) {
+                sentences.push(decodedPhrase);
+            }
+        }
+    }
+
+    // Conversion au format Markdown
+    let markdown = `# ${title}\n\n`;
+    sentences.forEach((sentence, index) => {
+        markdown += `${index + 1}. ${sentence}\n`;
+    });
+
+    return markdown;
+}
+```
+
+## Mapping des codes de langue
+
+Le tableau suivant montre la correspondance entre les anciens codes de langue et les nouveaux :
+
+| Ancien code | Nouveau code |
+| ----------- | ------------ |
+| fr          | fr-FR        |
+| en          | en-US        |
+| es          | es-ES        |
+| de          | de-DE        |
+| it          | it-IT        |
+
+## Limites et considérations
+
+### Limites de la migration automatique
+
+-   Les formatages spéciaux (gras, italique) ne sont pas présents dans l'ancien format et ne seront donc pas récupérés
+-   Les métadonnées avancées (auteur, niveau, etc.) devront être ajoutées manuellement
+-   Le paramètre d'ordre aléatoire (`a=1`) est converti, mais d'autres paramètres peuvent être perdus
+
+### Avantages du nouveau format
+
+-   Meilleure lisibilité
+-   URLs plus courtes
+-   Possibilité d'ajouter des métadonnées et du formatage
+-   Compatibilité avec des éditeurs Markdown externes
+-   Stockage local ou cloud du fichier .md
+
+## FAQ sur la migration
+
+**Q : Puis-je migrer plusieurs dictées à la fois ?**  
+R : Non, l'outil de migration traite une dictée à la fois. Pour les utilisateurs avec de nombreuses dictées, contactez-nous pour une solution personnalisée.
+
+**Q : Les anciennes URLs continueront-elles à fonctionner ?**  
+R : Oui, pour assurer la compatibilité, les anciennes URLs resteront fonctionnelles, mais un message vous invitera à migrer vers le nouveau format.
+
+**Q : Que se passe-t-il si la conversion échoue ?**  
+R : L'application affichera un message d'erreur précis. Vous pourrez alors essayer la méthode de migration manuelle ou nous contacter pour obtenir de l'aide.
+
+**Q : Comment partager mes dictées migrées ?**  
+R : Après la migration, vous pouvez télécharger le fichier Markdown et le partager par e-mail, services cloud ou via l'URL directe générée par l'application.
+
+## Ressources supplémentaires
+
+-   [Guide d'utilisation](GUIDE_UTILISATION.md) - Pour en savoir plus sur l'utilisation de la nouvelle application
+-   [Format Markdown](FORMAT_MARKDOWN.md) - Documentation détaillée du format Markdown utilisé
+-   [Exemples de dictées](https://github.com/micetf/dictee-markdown/tree/main/examples) - Collection d'exemples au format Markdown

--- a/src/components/dictee/DicteeForm.jsx
+++ b/src/components/dictee/DicteeForm.jsx
@@ -29,14 +29,22 @@ const DicteeForm = ({
 
     // Générer l'aperçu Markdown
     useEffect(() => {
-        let md = `# ${title}\n\n`;
+        let md = `# ${title}\n`;
+
+        // Inclure la langue dans l'aperçu
+        if (lang) {
+            md += `<!-- lang:${lang} -->\n`;
+        }
+
+        md += "\n";
+
         sentences.forEach((sentence, index) => {
             if (sentence.trim()) {
                 md += `${index + 1}. ${sentence}\n`;
             }
         });
         setMarkdownPreview(md);
-    }, [title, sentences]);
+    }, [title, sentences, lang]);
 
     // Validation du formulaire
     const validateForm = () => {
@@ -110,14 +118,16 @@ const DicteeForm = ({
                         fullWidth
                         error={errors.title}
                     />
-
                     {/* Langue de la dictée */}
                     <div>
                         <label
                             htmlFor="lang"
                             className="block text-sm font-medium text-gray-700 mb-1"
                         >
-                            Langue
+                            Langue de la dictée
+                            <span className="ml-1 text-xs text-gray-500">
+                                (pour la synthèse vocale)
+                            </span>
                         </label>
                         <select
                             id="lang"
@@ -126,14 +136,38 @@ const DicteeForm = ({
                             onChange={(e) => setLang(e.target.value)}
                             className="block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
                         >
-                            <option value="fr">Français</option>
-                            <option value="en">Anglais</option>
-                            <option value="es">Espagnol</option>
-                            <option value="de">Allemand</option>
-                            <option value="it">Italien</option>
+                            <option value="fr">Français (fr)</option>
+                            <option value="fr-FR">
+                                Français - France (fr-FR)
+                            </option>
+                            <option value="fr-CA">
+                                Français - Canada (fr-CA)
+                            </option>
+                            <option value="en">Anglais (en)</option>
+                            <option value="en-US">
+                                Anglais - États-Unis (en-US)
+                            </option>
+                            <option value="en-GB">
+                                Anglais - Royaume-Uni (en-GB)
+                            </option>
+                            <option value="es">Espagnol (es)</option>
+                            <option value="es-ES">
+                                Espagnol - Espagne (es-ES)
+                            </option>
+                            <option value="de">Allemand (de)</option>
+                            <option value="de-DE">
+                                Allemand - Allemagne (de-DE)
+                            </option>
+                            <option value="it">Italien (it)</option>
+                            <option value="it-IT">
+                                Italien - Italie (it-IT)
+                            </option>
                         </select>
+                        <p className="mt-1 text-xs text-gray-500">
+                            La langue sera sauvegardée dans le fichier Markdown
+                            et utilisée pour la synthèse vocale.
+                        </p>
                     </div>
-
                     {/* Phrases de la dictée */}
                     <div>
                         <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -201,7 +235,6 @@ const DicteeForm = ({
                             </div>
                         </div>
                     </div>
-
                     {/* Aperçu Markdown */}
                     <div>
                         <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -211,7 +244,6 @@ const DicteeForm = ({
                             {markdownPreview}
                         </div>
                     </div>
-
                     {/* Boutons d'action */}
                     <div className="flex justify-end space-x-3 pt-4">
                         <Button

--- a/src/pages/import/MarkdownPreview.jsx
+++ b/src/pages/import/MarkdownPreview.jsx
@@ -29,10 +29,42 @@ const MarkdownPreview = ({
                     <h3 className="text-lg font-medium text-gray-900 mb-2">
                         {previewData.title}
                     </h3>
-                    <p className="text-sm text-gray-500">
-                        Langue: {previewData.lang} ·{" "}
-                        {previewData.sentences.length} phrase(s)
-                    </p>
+                    <div className="flex flex-wrap gap-2 text-sm text-gray-500">
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full bg-blue-100 text-blue-800">
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                className="h-4 w-4 mr-1"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                            >
+                                <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"
+                                />
+                            </svg>
+                            Langue: {previewData.lang}
+                        </span>
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full bg-green-100 text-green-800">
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                className="h-4 w-4 mr-1"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                            >
+                                <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"
+                                />
+                            </svg>
+                            {previewData.sentences.length} phrase(s)
+                        </span>
+                    </div>
                 </div>
 
                 <div className="bg-gray-50 p-4 rounded-md mb-6">

--- a/src/services/MarkdownService.js
+++ b/src/services/MarkdownService.js
@@ -18,6 +18,15 @@ class MarkdownService {
         const titleMatch = lines[0].match(/^# (.+)$/);
         const title = titleMatch ? titleMatch[1].trim() : "Sans titre";
 
+        // Extraire la langue depuis les métadonnées (commentaire HTML)
+        let lang = "fr"; // Valeur par défaut
+        const langMatch = markdownContent.match(
+            /<!--\s*lang:([a-z]{2}(?:-[A-Z]{2})?)\s*-->/
+        );
+        if (langMatch && langMatch[1]) {
+            lang = langMatch[1].trim();
+        }
+
         // Extraire les phrases (lignes numérotées)
         const sentences = [];
         const sentenceRegex = /^\d+\.\s+(.+)$/;
@@ -32,7 +41,7 @@ class MarkdownService {
         return {
             title,
             sentences,
-            lang: "fr", // Par défaut
+            lang,
         };
     }
 
@@ -46,9 +55,17 @@ class MarkdownService {
             return "# Sans titre\n\n";
         }
 
-        const { title, sentences } = dictee;
+        const { title, sentences, lang } = dictee;
 
-        let markdown = `# ${title}\n\n`;
+        // Générer le Markdown avec métadonnées
+        let markdown = `# ${title}\n`;
+
+        // Ajouter la langue comme commentaire HTML si disponible
+        if (lang) {
+            markdown += `<!-- lang:${lang} -->\n`;
+        }
+
+        markdown += "\n";
 
         sentences.forEach((sentence, index) => {
             if (sentence && sentence.trim()) {
@@ -112,6 +129,29 @@ class MarkdownService {
         }
 
         return false;
+    }
+
+    /**
+     * Extrait les métadonnées d'un contenu Markdown
+     * @param {string} markdownContent - Le contenu Markdown
+     * @returns {Object} Les métadonnées extraites
+     */
+    extractMetadata(markdownContent) {
+        if (!markdownContent) {
+            return { lang: "fr" };
+        }
+
+        const metadata = { lang: "fr" };
+
+        // Extraire la langue
+        const langMatch = markdownContent.match(
+            /<!--\s*lang:([a-z]{2}(?:-[A-Z]{2})?)\s*-->/
+        );
+        if (langMatch && langMatch[1]) {
+            metadata.lang = langMatch[1].trim();
+        }
+
+        return metadata;
     }
 }
 


### PR DESCRIPTION
- Implémentation d'un format étendu avec métadonnées pour stocker la langue
- Ajout de commentaires HTML <!-- lang:xx --> pour préserver la compatibilité
- Mise à jour de l'interface utilisateur pour mieux exposer cette fonctionnalité
- Extension du sélecteur de langue avec plus d'options
- Amélioration de la documentation sur le format Markdown
- Mise à jour de la prévisualisation pour afficher les métadonnées

Cette amélioration permet une meilleure expérience utilisateur avec la synthèse vocale et résout le problème de perte d'information de langue lors de l'export/import des dictées.